### PR TITLE
Allow to pass a measured void fill weight to package

### DIFF
--- a/lib/physical/package.rb
+++ b/lib/physical/package.rb
@@ -7,7 +7,7 @@ module Physical
 
     def initialize(id: nil, container: Physical::Box.new, items: [], void_fill_density: 0, void_fill_density_unit: :g)
       @id = id || SecureRandom.uuid
-      @void_fill_density = Measured::Weight(void_fill_density, void_fill_density_unit)
+      @void_fill_density = measured_void_fill_density(void_fill_density, void_fill_density_unit)
       @container = container
       @items = Set[*items]
     end
@@ -34,6 +34,15 @@ module Physical
       return Measured::Weight(0, :g) if container.volume.value.infinite?
 
       Measured::Weight(void_fill_density.value * remaining_volume.value, void_fill_density.unit)
+    end
+
+    def measured_void_fill_density(void_fill_density, void_fill_density_unit)
+      case void_fill_density
+      when Measured::Weight
+        void_fill_density
+      else
+        Measured::Weight(void_fill_density, void_fill_density_unit)
+      end
     end
   end
 end

--- a/spec/physical/package_spec.rb
+++ b/spec/physical/package_spec.rb
@@ -129,4 +129,37 @@ RSpec.describe Physical::Package do
       expect(subject.weight).to eq(Measured::Weight(1399.88, :g))
     end
   end
+
+  describe '#void_fill_weight' do
+    subject { package.void_fill_weight }
+
+    shared_examples 'returning a measured weight' do
+      it 'returns a measured weight' do
+        is_expected.to be_a(Measured::Weight)
+        expect(subject.convert_to(:g).value.to_f).to eq(0.007)
+      end
+    end
+
+    context 'when void fill density is given' do
+      let(:container) { Physical::Box.new(dimensions: [1, 1, 1]) }
+
+      context 'as number' do
+        let(:args) { {container: container, void_fill_density: 0.007} }
+
+        it_behaves_like 'returning a measured weight'
+
+        context 'and void fill density unit given' do
+          let(:args) { {container: container, void_fill_density: 0.000007, void_fill_density_unit: :kg} }
+
+          it_behaves_like 'returning a measured weight'
+        end
+      end
+
+      context 'as measured weight' do
+        let(:args) { {container: container, void_fill_density: Measured::Weight.new(7, :mg)} }
+
+        it_behaves_like 'returning a measured weight'
+      end
+    end
+  end
 end


### PR DESCRIPTION
Instead of the necessity to pass a void fill density value and unit,
we now also allow to pass a Measured::Weight