### PR TITLE
Fix conversion errors when using BigDecimal

### DIFF
--- a/lib/physical/cuboid.rb
+++ b/lib/physical/cuboid.rb
@@ -8,15 +8,15 @@ module Physical
 
     def initialize(id: nil, dimensions: [], dimension_unit: :cm, weight: 0, weight_unit: :g, properties: {})
       @id = id || SecureRandom.uuid
-      @weight = Measured::Weight(weight, weight_unit).convert_to(:g)
-      @dimensions = dimensions.map { |dimension| Measured::Length.new(dimension, dimension_unit).convert_to(:cm) }
+      @weight = Measured::Weight(weight, weight_unit)
+      @dimensions = dimensions.map { |dimension| Measured::Length.new(dimension, dimension_unit) }
       @dimensions.fill(Measured::Length(self.class::DEFAULT_LENGTH, dimension_unit), @dimensions.length..2)
       @width, @height, @depth = *@dimensions
       @properties = properties
     end
 
     def volume
-      Measured::Volume(dimensions.map(&:value).reduce(1, &:*), :ml)
+      Measured::Volume(dimensions.map { |d| d.convert_to(:cm).value }.reduce(1, &:*), :ml)
     end
 
     def ==(other)

--- a/lib/physical/spec_support/shared_examples.rb
+++ b/lib/physical/spec_support/shared_examples.rb
@@ -1,23 +1,23 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'a cuboid' do
-  let(:args) { {dimensions: [1, 2, 3], dimension_unit: :cm} }
+  let(:args) { {dimensions: [1.1, 2.2, 3.3], dimension_unit: :cm} }
 
   it { is_expected.to be_a(Physical::Cuboid) }
 
-  it "has dimensions as Measured::Length objects" do
+  it "has dimensions as Measured::Length objects with rational values" do
     expect(subject.dimensions).to eq(
       [
-        Measured::Length.new(1, :cm),
-        Measured::Length.new(2, :cm),
-        Measured::Length.new(3, :cm)
+        Measured::Length.new(1.1, :cm),
+        Measured::Length.new(2.2, :cm),
+        Measured::Length.new(3.3, :cm)
       ]
     )
   end
 
   it "has getter methods for each dimension as Measured::Length object" do
-    expect(subject.width).to eq(Measured::Length.new(1, :cm))
-    expect(subject.height).to eq(Measured::Length.new(2, :cm))
-    expect(subject.depth).to eq(Measured::Length.new(3, :cm))
+    expect(subject.width).to eq(Measured::Length.new(1.1, :cm))
+    expect(subject.height).to eq(Measured::Length.new(2.2, :cm))
+    expect(subject.depth).to eq(Measured::Length.new(3.3, :cm))
   end
 end

--- a/spec/physical/box_spec.rb
+++ b/spec/physical/box_spec.rb
@@ -90,8 +90,8 @@ RSpec.describe Physical::Box do
     subject { FactoryBot.build(:physical_box) }
 
     it 'has coherent attributes' do
-      expect(subject.dimensions.map(&:value)).to eq([40, 50, 60])
-      expect(subject.weight.value).to eq(100)
+      expect(subject.dimensions.map { |d| d.convert_to(:cm).value }).to eq([40, 50, 60])
+      expect(subject.weight.convert_to(:g).value).to eq(100)
     end
   end
 end


### PR DESCRIPTION
When we initialize a cuboid's dimension or weight with a Float value, as
we do in our tests frequently, this value will get cast to a Ruby
Rational by the Measured gem. The extreme exactness of the Rational
class represents a value of `1.1` as follows:

irb(main):001:0> 1.1.to_r
=> (2476979795053773/2251799813685248)

However, the real value of `1.1` as we want it is `(11/10)`. We can
obtain this value by first casting to `BigDecimal`, and then casting to
Rational:

irb(main):004:0> 1.1.to_d.to_r
=> (11/10)

In order to get Ruby's fantastic `to_d` method on Float, we need to
require `bigdecimal/util`.