### PR TITLE
Define Length, Width, and Height as relative sizes

### DIFF
--- a/lib/physical/cuboid.rb
+++ b/lib/physical/cuboid.rb
@@ -4,16 +4,21 @@ require 'measured'
 
 module Physical
   class Cuboid
-    attr_reader :dimensions, :width, :height, :depth, :weight, :id, :properties
+    attr_reader :dimensions, :length, :width, :height, :weight, :id, :properties
 
     def initialize(id: nil, dimensions: [], dimension_unit: :cm, weight: 0, weight_unit: :g, properties: {})
       @id = id || SecureRandom.uuid
       @weight = Measured::Weight(weight, weight_unit)
-      @dimensions = dimensions.map { |dimension| Measured::Length.new(dimension, dimension_unit) }
+      @dimensions = dimensions.map { |dimension| Measured::Length.new(dimension, dimension_unit) }.sort
       @dimensions.fill(Measured::Length(self.class::DEFAULT_LENGTH, dimension_unit), @dimensions.length..2)
-      @width, @height, @depth = *@dimensions
+      @length, @width, @height = *@dimensions.reverse
       @properties = properties
     end
+
+    alias :x :length
+    alias :y :width
+    alias :z :height
+    alias :depth :height
 
     def volume
       Measured::Volume(dimensions.map { |d| d.convert_to(:cm).value }.reduce(1, &:*), :ml)

--- a/lib/physical/package.rb
+++ b/lib/physical/package.rb
@@ -12,7 +12,7 @@ module Physical
       @items = Set[*items]
     end
 
-    def_delegator :@container, :dimensions
+    delegate [:dimensions, :width, :length, :height, :depth, :x, :y, :z] => :container
 
     def <<(item)
       @items.add(item)

--- a/lib/physical/spec_support/shared_examples.rb
+++ b/lib/physical/spec_support/shared_examples.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'a cuboid' do
-  let(:args) { {dimensions: [1.1, 2.2, 3.3], dimension_unit: :cm} }
+  let(:args) { {dimensions: [1.1, 2.2, 3.3].shuffle, dimension_unit: :cm} }
 
   it { is_expected.to be_a(Physical::Cuboid) }
 
@@ -16,8 +16,12 @@ RSpec.shared_examples 'a cuboid' do
   end
 
   it "has getter methods for each dimension as Measured::Length object" do
-    expect(subject.width).to eq(Measured::Length.new(1.1, :cm))
-    expect(subject.height).to eq(Measured::Length.new(2.2, :cm))
-    expect(subject.depth).to eq(Measured::Length.new(3.3, :cm))
+    expect(subject.length).to eq(Measured::Length.new(3.3, :cm))
+    expect(subject.x).to eq(Measured::Length.new(3.3, :cm))
+    expect(subject.width).to eq(Measured::Length.new(2.2, :cm))
+    expect(subject.y).to eq(Measured::Length.new(2.2, :cm))
+    expect(subject.height).to eq(Measured::Length.new(1.1, :cm))
+    expect(subject.z).to eq(Measured::Length.new(1.1, :cm))
+    expect(subject.depth).to eq(Measured::Length.new(1.1, :cm))
   end
 end

--- a/lib/physical/version.rb
+++ b/lib/physical/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Physical
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/lib/physical/version.rb
+++ b/lib/physical/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Physical
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end

--- a/spec/physical/package_spec.rb
+++ b/spec/physical/package_spec.rb
@@ -93,6 +93,16 @@ RSpec.describe Physical::Package do
     end
   end
 
+  describe 'dimension methods' do
+    let(:args) { { container: Physical::Box.new(dimensions: [1,2,3]) } }
+
+    it 'forwards them to the container' do
+      expect(package.length).to eq(Measured::Length(3, :cm))
+      expect(package.width).to eq(Measured::Length(2, :cm))
+      expect(package.depth).to eq(Measured::Length(1, :cm))
+    end
+  end
+
   describe "#remaining_volume" do
     let(:args) do
       {


### PR DESCRIPTION
According to ActiveShipping's source code, length, width and height are
defined as the longest, middle, and shortest dimension of a Cuboid. See
https://github.com/Shopify/active_shipping/blob/master/lib/active_shipping/package.rb#L154-L156
and
https://github.com/Shopify/active_shipping/blob/master/lib/active_shipping/package.rb#L143-L145
for "proof".