### PR TITLE
Physical 0.2

### DIFF
--- a/lib/physical.rb
+++ b/lib/physical.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "physical/types"
 require "physical/version"
 require "physical/cuboid"
 require "physical/box"

--- a/lib/physical/box.rb
+++ b/lib/physical/box.rb
@@ -5,11 +5,27 @@ require 'measured'
 module Physical
   class Box < Cuboid
     DEFAULT_LENGTH = BigDecimal::INFINITY
-    attr_reader :inner_dimensions
+    attr_reader :inner_dimensions,
+                :inner_length,
+                :inner_width,
+                :inner_height
 
     def initialize(inner_dimensions: [], **args)
       super args
       @inner_dimensions = fill_dimensions(inner_dimensions)
+      @inner_length, @inner_width, @inner_height = *@inner_dimensions.reverse
+    end
+
+    alias :inner_x :inner_length
+    alias :inner_y :inner_width
+    alias :inner_z :inner_height
+    alias :inner_depth :inner_height
+
+    def inner_volume
+      Measured::Volume(
+        inner_dimensions.map { |d| d.convert_to(:cm).value }.reduce(1, &:*),
+        :ml
+      )
     end
   end
 end

--- a/lib/physical/box.rb
+++ b/lib/physical/box.rb
@@ -5,5 +5,11 @@ require 'measured'
 module Physical
   class Box < Cuboid
     DEFAULT_LENGTH = BigDecimal::INFINITY
+    attr_reader :inner_dimensions
+
+    def initialize(inner_dimensions: [], **args)
+      super args
+      @inner_dimensions = fill_dimensions(inner_dimensions)
+    end
   end
 end

--- a/lib/physical/box.rb
+++ b/lib/physical/box.rb
@@ -12,7 +12,7 @@ module Physical
 
     def initialize(inner_dimensions: [], **args)
       super args
-      @inner_dimensions = fill_dimensions(inner_dimensions)
+      @inner_dimensions = fill_dimensions(Types::Dimensions[inner_dimensions])
       @inner_length, @inner_width, @inner_height = *@inner_dimensions.reverse
     end
 

--- a/lib/physical/cuboid.rb
+++ b/lib/physical/cuboid.rb
@@ -9,9 +9,8 @@ module Physical
     def initialize(id: nil, dimensions: [], weight: nil, properties: {})
       @id = id || SecureRandom.uuid
       @weight = weight || Measured::Weight(0, :g)
-      @dimensions = dimensions
-      @dimensions.fill(Measured::Length(self.class::DEFAULT_LENGTH, :cm), @dimensions.length..2)
-      @dimensions = dimensions.sort
+      @dimensions = []
+      @dimensions = fill_dimensions(dimensions)
       @length, @width, @height = *@dimensions.reverse
       @properties = properties
     end
@@ -27,6 +26,14 @@ module Physical
 
     def ==(other)
       id == other.id
+    end
+
+    private
+
+    def fill_dimensions(dimensions)
+      dimensions.fill(dimensions.length..2) do |index|
+        @dimensions[index] || Measured::Length(self.class::DEFAULT_LENGTH, :cm)
+      end.sort
     end
   end
 end

--- a/lib/physical/cuboid.rb
+++ b/lib/physical/cuboid.rb
@@ -6,11 +6,11 @@ module Physical
   class Cuboid
     attr_reader :dimensions, :length, :width, :height, :weight, :id, :properties
 
-    def initialize(id: nil, dimensions: [], weight: nil, properties: {})
+    def initialize(id: nil, dimensions: [], weight: Measured::Weight(0, :g), properties: {})
       @id = id || SecureRandom.uuid
-      @weight = weight || Measured::Weight(0, :g)
+      @weight = Types::Weight[weight]
       @dimensions = []
-      @dimensions = fill_dimensions(dimensions)
+      @dimensions = fill_dimensions(Types::Dimensions[dimensions])
       @length, @width, @height = *@dimensions.reverse
       @properties = properties
     end

--- a/lib/physical/cuboid.rb
+++ b/lib/physical/cuboid.rb
@@ -6,11 +6,12 @@ module Physical
   class Cuboid
     attr_reader :dimensions, :length, :width, :height, :weight, :id, :properties
 
-    def initialize(id: nil, dimensions: [], dimension_unit: :cm, weight: 0, weight_unit: :g, properties: {})
+    def initialize(id: nil, dimensions: [], weight: nil, properties: {})
       @id = id || SecureRandom.uuid
-      @weight = Measured::Weight(weight, weight_unit)
-      @dimensions = dimensions.map { |dimension| Measured::Length.new(dimension, dimension_unit) }.sort
-      @dimensions.fill(Measured::Length(self.class::DEFAULT_LENGTH, dimension_unit), @dimensions.length..2)
+      @weight = weight || Measured::Weight(0, :g)
+      @dimensions = dimensions
+      @dimensions.fill(Measured::Length(self.class::DEFAULT_LENGTH, :cm), @dimensions.length..2)
+      @dimensions = dimensions.sort
       @length, @width, @height = *@dimensions.reverse
       @properties = properties
     end

--- a/lib/physical/package.rb
+++ b/lib/physical/package.rb
@@ -27,7 +27,7 @@ module Physical
     end
 
     def remaining_volume
-      container.volume - items.map(&:volume).reduce(Measured::Volume(0, :ml), &:+)
+      container.inner_volume - items.map(&:volume).reduce(Measured::Volume(0, :ml), &:+)
     end
 
     def void_fill_weight

--- a/lib/physical/package.rb
+++ b/lib/physical/package.rb
@@ -5,14 +5,14 @@ module Physical
     extend Forwardable
     attr_reader :container, :items, :void_fill_density, :id
 
-    def initialize(id: nil, container: nil, items: [], void_fill_density: Measured::Weight(0, :g), dimensions: nil, weight: nil)
+    def initialize(id: nil, container: nil, items: [], void_fill_density: Measured::Weight(0, :g), dimensions: nil, weight: nil, properties: {})
       @id = id || SecureRandom.uuid
       @void_fill_density = Types::Weight[void_fill_density]
-      @container = container || Physical::Box.new(dimensions: dimensions || [], weight: weight || Measured::Weight(0, :g))
+      @container = container || Physical::Box.new(dimensions: dimensions || [], weight: weight || Measured::Weight(0, :g), properties: properties)
       @items = Set[*items]
     end
 
-    delegate [:dimensions, :width, :length, :height, :depth, :x, :y, :z] => :container
+    delegate [:dimensions, :width, :length, :height, :depth, :x, :y, :z, :properties] => :container
 
     def <<(item)
       @items.add(item)

--- a/lib/physical/package.rb
+++ b/lib/physical/package.rb
@@ -5,10 +5,10 @@ module Physical
     extend Forwardable
     attr_reader :container, :items, :void_fill_density, :id
 
-    def initialize(id: nil, container: Physical::Box.new, items: [], void_fill_density: Measured::Weight(0, :g))
+    def initialize(id: nil, container: nil, items: [], void_fill_density: Measured::Weight(0, :g), dimensions: nil, weight: nil)
       @id = id || SecureRandom.uuid
       @void_fill_density = Types::Weight[void_fill_density]
-      @container = container
+      @container = container || Physical::Box.new(dimensions: dimensions || [], weight: weight || Measured::Weight(0, :g))
       @items = Set[*items]
     end
 

--- a/lib/physical/package.rb
+++ b/lib/physical/package.rb
@@ -5,9 +5,9 @@ module Physical
     extend Forwardable
     attr_reader :container, :items, :void_fill_density, :id
 
-    def initialize(id: nil, container: Physical::Box.new, items: [], void_fill_density: 0, void_fill_density_unit: :g)
+    def initialize(id: nil, container: Physical::Box.new, items: [], void_fill_density: Measured::Weight(0, :g))
       @id = id || SecureRandom.uuid
-      @void_fill_density = measured_void_fill_density(void_fill_density, void_fill_density_unit)
+      @void_fill_density = void_fill_density
       @container = container
       @items = Set[*items]
     end
@@ -34,15 +34,6 @@ module Physical
       return Measured::Weight(0, :g) if container.volume.value.infinite?
 
       Measured::Weight(void_fill_density.value * remaining_volume.value, void_fill_density.unit)
-    end
-
-    def measured_void_fill_density(void_fill_density, void_fill_density_unit)
-      case void_fill_density
-      when Measured::Weight
-        void_fill_density
-      else
-        Measured::Weight(void_fill_density, void_fill_density_unit)
-      end
     end
   end
 end

--- a/lib/physical/package.rb
+++ b/lib/physical/package.rb
@@ -7,7 +7,7 @@ module Physical
 
     def initialize(id: nil, container: Physical::Box.new, items: [], void_fill_density: Measured::Weight(0, :g))
       @id = id || SecureRandom.uuid
-      @void_fill_density = void_fill_density
+      @void_fill_density = Types::Weight[void_fill_density]
       @container = container
       @items = Set[*items]
     end

--- a/lib/physical/spec_support/factories/box_factory.rb
+++ b/lib/physical/spec_support/factories/box_factory.rb
@@ -4,10 +4,8 @@ require 'factory_bot'
 
 FactoryBot.define do
   factory :physical_box, class: "Physical::Box" do
-    dimensions { [4, 5, 6] }
-    dimension_unit { :dm }
-    weight { 0.1 }
-    weight_unit { :kg }
+    dimensions { [4, 5, 6].map { |d| Measured::Length(d, :dm) } }
+    weight { Measured::Weight(0.1, :kg) }
     initialize_with { new(attributes) }
   end
 end

--- a/lib/physical/spec_support/factories/box_factory.rb
+++ b/lib/physical/spec_support/factories/box_factory.rb
@@ -5,6 +5,7 @@ require 'factory_bot'
 FactoryBot.define do
   factory :physical_box, class: "Physical::Box" do
     dimensions { [4, 5, 6].map { |d| Measured::Length(d, :dm) } }
+    inner_dimensions { dimensions.map { |d| d - Measured::Length(1, :cm) } }
     weight { Measured::Weight(0.1, :kg) }
     initialize_with { new(attributes) }
   end

--- a/lib/physical/spec_support/factories/item_factory.rb
+++ b/lib/physical/spec_support/factories/item_factory.rb
@@ -4,10 +4,8 @@ require 'factory_bot'
 
 FactoryBot.define do
   factory :physical_item, class: "Physical::Item" do
-    dimensions { [1, 2, 3] }
-    dimension_unit { :cm }
-    weight { 50 }
-    weight_unit { :g }
+    dimensions { [1, 2, 3].map { |d| Measured::Length(d, :cm)} }
+    weight { Measured::Weight(50, :g) }
     initialize_with { new(attributes) }
   end
 end

--- a/lib/physical/spec_support/factories/package_factory.rb
+++ b/lib/physical/spec_support/factories/package_factory.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
   factory :physical_package, class: "Physical::Package" do
     container { FactoryBot.build(:physical_box) }
     items { build_list(:physical_item, 2) }
-    void_fill_density { 0.01 }
+    void_fill_density { Measured::Weight(0.01, :g) }
     initialize_with { new(attributes) }
   end
 end

--- a/lib/physical/spec_support/shared_examples.rb
+++ b/lib/physical/spec_support/shared_examples.rb
@@ -1,7 +1,15 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'a cuboid' do
-  let(:args) { {dimensions: [1.1, 2.2, 3.3].shuffle, dimension_unit: :cm} }
+  let(:args) do
+    {
+      dimensions: [
+        Measured::Length.new(1.1, :cm),
+        Measured::Length.new(2.2, :cm),
+        Measured::Length.new(3.3, :cm)
+      ].shuffle
+    }
+  end
 
   it { is_expected.to be_a(Physical::Cuboid) }
 

--- a/lib/physical/types.rb
+++ b/lib/physical/types.rb
@@ -1,0 +1,14 @@
+require 'measured'
+require 'dry-types'
+
+module Physical
+  module Types
+    include Dry::Types.module
+
+    Weight = Types.Instance(::Measured::Weight)
+    Length = Types.Instance(::Measured::Length)
+    Volume = Types.Instance(::Measured::Volume)
+
+    Dimensions = Types::Strict::Array.of(Length)
+  end
+end

--- a/lib/physical/version.rb
+++ b/lib/physical/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Physical
-  VERSION = "0.1.4"
+  VERSION = "0.2.0"
 end

--- a/physical.gemspec
+++ b/physical.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.4'
   spec.add_runtime_dependency "carmen", "~> 1.0"
   spec.add_runtime_dependency "measured", "~> 2.4.0"
+  spec.add_runtime_dependency "dry-types", "~> 1.0.0"
 
   spec.add_development_dependency "bundler", [">= 1.16", "< 3"]
   spec.add_development_dependency "factory_bot", "~> 4.8"

--- a/spec/physical/box_spec.rb
+++ b/spec/physical/box_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Physical::Box do
   it_behaves_like 'a cuboid'
 
   context "when given a one-element dimensions array" do
-    let(:args) { {dimensions: [2], dimension_unit: :cm} }
+    let(:args) { {dimensions: [Measured::Length(2, :cm)]} }
 
     specify "the other dimensions are filled up with BigDecimal::INFINITY" do
       expect(subject.dimensions).to eq(
@@ -20,7 +20,7 @@ RSpec.describe Physical::Box do
   end
 
   context "when given a two-element dimensions array" do
-    let(:args) { {dimensions: [1, 2], dimension_unit: :cm} }
+    let(:args) { {dimensions: [1, 2].map { |d| Measured::Length(d, :cm) }} }
 
     it "the last dimension is filled up with BigDecimal::INFINITY" do
       expect(subject.dimensions).to eq(
@@ -51,7 +51,7 @@ RSpec.describe Physical::Box do
     subject { described_class.new(args).volume }
 
     context "if all three dimensions are given" do
-      let(:args) { {dimensions: [1.1, 2.1, 3.2], dimension_unit: :cm} }
+      let(:args) { {dimensions: [1.1, 2.1, 3.2].map { |d| Measured::Length(d, :cm) }} }
 
       it "returns the correct volume" do
         expect(subject).to eq(Measured::Volume(7.392, :ml))
@@ -59,7 +59,7 @@ RSpec.describe Physical::Box do
     end
 
     context "if a dimension is missing" do
-      let(:args) { {dimensions: [1.1, 2.1], dimension_unit: :cm} }
+      let(:args) { {dimensions: [1.1, 2.1].map { |d| Measured::Length(d, :cm) }} }
 
       it "is infinitely large" do
         expect(subject).to eq(Measured::Volume(BigDecimal::INFINITY, :ml))
@@ -76,13 +76,8 @@ RSpec.describe Physical::Box do
     end
 
     context "with a weight unit given" do
-      let(:args) { {weight: 1, weight_unit: :lb} }
+      let(:args) { {weight: Measured::Weight(1, :lbs)} }
       it { is_expected.to eq(Measured::Weight(453.59237, :g)) }
-    end
-
-    context "with a weight given" do
-      let(:args) { {weight: 200} }
-      it { is_expected.to eq(Measured::Weight(200, :g)) }
     end
   end
 

--- a/spec/physical/box_spec.rb
+++ b/spec/physical/box_spec.rb
@@ -89,4 +89,42 @@ RSpec.describe Physical::Box do
       expect(subject.weight.convert_to(:g).value).to eq(100)
     end
   end
+
+  describe '#inner_dimensions' do
+    subject { described_class.new(args).inner_dimensions }
+
+    context 'if all values are given' do
+      let(:args) do
+        {
+          dimensions: [1.1, 2.1, 3.2].map { |d| Measured::Length(d, :cm) },
+          inner_dimensions: [3, 1, 2].map { |d| Measured::Length(d, :cm) }
+        }
+      end
+
+      it do
+        is_expected.to eq([
+          Measured::Length.new(1, :cm),
+          Measured::Length.new(2, :cm),
+          Measured::Length.new(3, :cm)
+        ])
+      end
+    end
+
+    context 'if a value is missing but outer dimensions are given' do
+      let(:args) do
+        {
+          dimensions: [1.1, 2.1, 3.2].map { |d| Measured::Length(d, :cm) },
+          inner_dimensions: [2, 1].map { |d| Measured::Length(d, :cm) }
+        }
+      end
+
+      it 'fills up with the outer dimensions' do
+        is_expected.to eq([
+          Measured::Length.new(1, :cm),
+          Measured::Length.new(2, :cm),
+          Measured::Length.new(3.2, :cm)
+        ])
+      end
+    end
+  end
 end

--- a/spec/physical/box_spec.rb
+++ b/spec/physical/box_spec.rb
@@ -127,4 +127,28 @@ RSpec.describe Physical::Box do
       end
     end
   end
+
+  describe 'inner length, width, height, volume' do
+    subject { described_class.new(args) }
+
+    let(:args) do
+      {
+        dimensions: [1.1, 2.1, 3.2].map { |d| Measured::Length(d, :cm) },
+        inner_dimensions: [2, 1, 3].map { |d| Measured::Length(d, :cm) }
+      }
+    end
+
+    it 'does the correct calculations' do
+      aggregate_failures do
+        expect(subject.inner_length).to eq(Measured::Length(3, :cm))
+        expect(subject.inner_width).to eq(Measured::Length(2, :cm))
+        expect(subject.inner_height).to eq(Measured::Length(1, :cm))
+        expect(subject.inner_x).to eq(Measured::Length(3, :cm))
+        expect(subject.inner_y).to eq(Measured::Length(2, :cm))
+        expect(subject.inner_z).to eq(Measured::Length(1, :cm))
+        expect(subject.inner_depth).to eq(Measured::Length(1, :cm))
+        expect(subject.inner_volume).to eq(Measured::Volume(6, :ml))
+      end
+    end
+  end
 end

--- a/spec/physical/item_spec.rb
+++ b/spec/physical/item_spec.rb
@@ -6,28 +6,28 @@ RSpec.describe Physical::Item do
   it_behaves_like 'a cuboid'
 
   context "when given a one-element dimensions array" do
-    let(:args) { {dimensions: [2], dimension_unit: :cm} }
+    let(:args) { {dimensions: [Measured::Length(2, :cm)]} }
 
     specify "the other dimensions are filled up with 0" do
       expect(subject.dimensions).to eq(
         [
-          Measured::Length.new(2, :cm),
           Measured::Length.new(0, :cm),
-          Measured::Length.new(0, :cm)
+          Measured::Length.new(0, :cm),
+          Measured::Length.new(2, :cm)
         ]
       )
     end
   end
 
   context "when given a two-element dimensions array" do
-    let(:args) { {dimensions: [1, 2], dimension_unit: :cm} }
+    let(:args) { {dimensions: [1, 2].map { |d| Measured::Length(d, :cm) }} }
 
     it "the last dimension is filled up with 0" do
       expect(subject.dimensions).to eq(
         [
+          Measured::Length.new(0, :cm),
           Measured::Length.new(1, :cm),
-          Measured::Length.new(2, :cm),
-          Measured::Length.new(0, :cm)
+          Measured::Length.new(2, :cm)
         ]
       )
     end
@@ -51,7 +51,7 @@ RSpec.describe Physical::Item do
     subject { described_class.new(args).volume }
 
     context "if all three dimensions are given" do
-      let(:args) { {dimensions: [1.1, 2.1, 3.2], dimension_unit: :cm} }
+      let(:args) { {dimensions: [1.1, 2.1, 3.2].map { |d| Measured::Length(d, :cm) }} }
 
       it "returns the correct volume" do
         expect(subject).to eq(Measured::Volume(7.392, :ml))
@@ -59,7 +59,7 @@ RSpec.describe Physical::Item do
     end
 
     context "if a dimension is missing" do
-      let(:args) { {dimensions: [1.1, 2.1], dimension_unit: :cm} }
+      let(:args) { {dimensions: [1.1, 2.1].map { |d| Measured::Length(d, :cm) }} }
 
       it "returns the correct volume" do
         expect(subject).to eq(Measured::Volume(0, :ml))
@@ -75,14 +75,9 @@ RSpec.describe Physical::Item do
       it { is_expected.to eq(Measured::Weight(0, :g)) }
     end
 
-    context "with a weight unit given" do
-      let(:args) { {weight: 1, weight_unit: :lb} }
+    context "with a weight" do
+      let(:args) { {weight: Measured::Weight(1, :lb)} }
       it { is_expected.to eq(Measured::Weight(453.59237, :g)) }
-    end
-
-    context "with a weight given" do
-      let(:args) { {weight: 200} }
-      it { is_expected.to eq(Measured::Weight(200, :g)) }
     end
   end
 

--- a/spec/physical/package_spec.rb
+++ b/spec/physical/package_spec.rb
@@ -137,6 +137,21 @@ RSpec.describe Physical::Package do
         expect(package.height).to eq(Measured::Length(1, :cm))
       end
     end
+
+    context 'with properties directly given' do
+      let(:args) do
+        {
+          properties: { foo: :bar }
+        }
+      end
+
+      it 'stores the properties on the container' do
+        aggregate_failures do
+          expect(package.properties).to eq({foo: :bar})
+          expect(package.container.properties).to eq(foo: :bar)
+        end
+      end
+    end
   end
 
   describe 'dimension methods' do

--- a/spec/physical/package_spec.rb
+++ b/spec/physical/package_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Physical::Package do
 
   describe "#<<" do
     let(:args) { {} }
-    let(:item) { Physical::Item.new(dimensions: [2, 2, 2]) }
+    let(:item) { Physical::Item.new(dimensions: [2, 2, 2].map { |d| Measured::Length(d, :cm) }) }
 
     subject { package.items }
 
@@ -51,7 +51,7 @@ RSpec.describe Physical::Package do
 
   describe "#>>" do
     let(:args) { {items: [item]} }
-    let(:item) { Physical::Item.new(dimensions: [2, 2, 2]) }
+    let(:item) { Physical::Item.new(dimensions: [2, 2, 2].map { |d| Measured::Length(d, :cm) }) }
 
     subject { package.items }
 

--- a/spec/physical/package_spec.rb
+++ b/spec/physical/package_spec.rb
@@ -91,6 +91,52 @@ RSpec.describe Physical::Package do
         expect(subject).to eq(Measured::Weight(0.8, :lb))
       end
     end
+
+    context 'with no container given but weight given' do
+      let(:args) do
+        {
+          weight: Measured::Weight(0.8, :lb),
+        }
+      end
+
+      it 'keeps that weight and has infinite dimensions' do
+        expect(package.weight).to eq(Measured::Weight(0.8, :lb))
+        expect(package.length).to eq(Measured::Length(Float::INFINITY, :cm))
+        expect(package.width).to eq(Measured::Length(Float::INFINITY, :cm))
+        expect(package.height).to eq(Measured::Length(Float::INFINITY, :cm))
+      end
+    end
+
+    context 'with no container given but dimensions given' do
+      let(:args) do
+        {
+          dimensions: [1, 2, 3].map { |d| Measured::Length(d, :cm) },
+        }
+      end
+
+      it 'keeps that weight and has infinite dimensions' do
+        expect(package.weight).to eq(Measured::Weight(0, :lb))
+        expect(package.length).to eq(Measured::Length(3, :cm))
+        expect(package.width).to eq(Measured::Length(2, :cm))
+        expect(package.height).to eq(Measured::Length(1, :cm))
+      end
+    end
+
+    context 'with no container given but dimensions and weight given' do
+      let(:args) do
+        {
+          weight: Measured::Weight(0.8, :lb),
+          dimensions: [1, 2, 3].map { |d| Measured::Length(d, :cm) },
+        }
+      end
+
+      it 'keeps that weight and has infinite dimensions' do
+        expect(package.weight).to eq(Measured::Weight(0.8, :lb))
+        expect(package.length).to eq(Measured::Length(3, :cm))
+        expect(package.width).to eq(Measured::Length(2, :cm))
+        expect(package.height).to eq(Measured::Length(1, :cm))
+      end
+    end
   end
 
   describe 'dimension methods' do

--- a/spec/physical/package_spec.rb
+++ b/spec/physical/package_spec.rb
@@ -65,10 +65,10 @@ RSpec.describe Physical::Package do
   describe "#weight" do
     let(:args) do
       {
-        container: Physical::Box.new(weight: 0.8, weight_unit: :lb),
+        container: Physical::Box.new(weight: Measured::Weight(0.8, :lb)),
         items: [
-          Physical::Item.new(weight: 0.2, weight_unit: :lb),
-          Physical::Item.new(weight: 1, weight_unit: :lb)
+          Physical::Item.new(weight: Measured::Weight(0.2, :lb)),
+          Physical::Item.new(weight: Measured::Weight(1, :lb))
         ]
       }
     end
@@ -82,7 +82,7 @@ RSpec.describe Physical::Package do
     context 'if no items given' do
       let(:args) do
         {
-          container: Physical::Box.new(weight: 0.8, weight_unit: :lb),
+          container: Physical::Box.new(weight: Measured::Weight(0.8, :lb)),
           items: []
         }
       end
@@ -94,7 +94,7 @@ RSpec.describe Physical::Package do
   end
 
   describe 'dimension methods' do
-    let(:args) { { container: Physical::Box.new(dimensions: [1,2,3]) } }
+    let(:args) { { container: Physical::Box.new(dimensions: [1,2,3].map { |d| Measured::Length(d, :cm)}) } }
 
     it 'forwards them to the container' do
       expect(package.length).to eq(Measured::Length(3, :cm))
@@ -106,8 +106,8 @@ RSpec.describe Physical::Package do
   describe "#remaining_volume" do
     let(:args) do
       {
-        container: Physical::Box.new(dimensions: [1, 2, 3]),
-        items: Physical::Item.new(dimensions: [1, 1, 1])
+        container: Physical::Box.new(dimensions: [1, 2, 3].map { |d| Measured::Length(d, :cm) }),
+        items: Physical::Item.new(dimensions: [1, 1, 1].map { |d| Measured::Length(d, :cm) })
       }
     end
 
@@ -143,32 +143,16 @@ RSpec.describe Physical::Package do
   describe '#void_fill_weight' do
     subject { package.void_fill_weight }
 
-    shared_examples 'returning a measured weight' do
-      it 'returns a measured weight' do
-        is_expected.to be_a(Measured::Weight)
-        expect(subject.convert_to(:g).value.to_f).to eq(0.007)
-      end
-    end
-
     context 'when void fill density is given' do
-      let(:container) { Physical::Box.new(dimensions: [1, 1, 1]) }
-
-      context 'as number' do
-        let(:args) { {container: container, void_fill_density: 0.007} }
-
-        it_behaves_like 'returning a measured weight'
-
-        context 'and void fill density unit given' do
-          let(:args) { {container: container, void_fill_density: 0.000007, void_fill_density_unit: :kg} }
-
-          it_behaves_like 'returning a measured weight'
-        end
-      end
+      let(:container) { Physical::Box.new(dimensions: [1, 1, 1].map { |d| Measured::Length(d, :cm) }) }
 
       context 'as measured weight' do
         let(:args) { {container: container, void_fill_density: Measured::Weight.new(7, :mg)} }
 
-        it_behaves_like 'returning a measured weight'
+        it 'returns a measured weight' do
+          is_expected.to be_a(Measured::Weight)
+          expect(subject.convert_to(:g).value.to_f).to eq(0.007)
+        end
       end
     end
   end

--- a/spec/physical/package_spec.rb
+++ b/spec/physical/package_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe Physical::Package do
     subject { FactoryBot.build(:physical_package) }
 
     it 'has plausible attributes' do
-      expect(subject.weight).to eq(Measured::Weight(1399.88, :g))
+      expect(subject.weight).to eq(Measured::Weight(1327.37, :g))
     end
   end
 
@@ -144,15 +144,18 @@ RSpec.describe Physical::Package do
     subject { package.void_fill_weight }
 
     context 'when void fill density is given' do
-      let(:container) { Physical::Box.new(dimensions: [1, 1, 1].map { |d| Measured::Length(d, :cm) }) }
+      let(:container) do
+        Physical::Box.new(
+          dimensions: [2, 2, 2].map { |d| Measured::Length(d, :cm) },
+          inner_dimensions: [1, 1, 1].map { |d| Measured::Length(d, :cm) }
+        )
+      end
 
-      context 'as measured weight' do
-        let(:args) { {container: container, void_fill_density: Measured::Weight.new(7, :mg)} }
+      let(:args) { {container: container, void_fill_density: Measured::Weight.new(7, :mg)} }
 
-        it 'returns a measured weight' do
-          is_expected.to be_a(Measured::Weight)
-          expect(subject.convert_to(:g).value.to_f).to eq(0.007)
-        end
+      it 'calculates the void fill weight from inner dimensions' do
+        is_expected.to be_a(Measured::Weight)
+        expect(subject.convert_to(:g).value.to_f).to eq(0.007)
       end
     end
   end


### PR DESCRIPTION
This PR changes how Cuboids are initialized: Instead of using Ruby Numerics and units as separate arguments to all Cuboids, we use Measured::{Weight,Length} directly.

This also allows creating a package specifying weight and dimensions directly.

The `dimensions`, `weight` and `void_fill_weight `are now typechecked, thank you  `dry-types`. 

Pending: Adapt the README file.