### PR TITLE
Do not sort dimensions for measuring

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,7 @@ You will be able to retrieve the package's weight and dimensions using the `#wei
 
 ### Convenience methods
 
-The length, width and height of a package are defined as the package's longest, middle, and shortest side, respectively. For the package from the previous example, `package.length` will be 5 inches, `package.width` will be 4 inches, and `package.height` will be 3 inches. Packages do not have a notion of "right side up" yet.
-
-The package's `length` is also accessible as `package.x`. The package's `width` is also accessible as `package.y`. The package's `height` is also accessible as `package.z` as well as `package.depth`.
+The length, width and height of a package are defined as the dimension array's first, second, and third argument, respectively. For the package from the previous example, `package.length` will be 3 inches, `package.width` will be 4 inches, and `package.height` will be 5 inches.
 
 ### Packages with Items
 

--- a/lib/physical/box.rb
+++ b/lib/physical/box.rb
@@ -13,13 +13,8 @@ module Physical
     def initialize(inner_dimensions: [], **args)
       super args
       @inner_dimensions = fill_dimensions(Types::Dimensions[inner_dimensions])
-      @inner_length, @inner_width, @inner_height = *@inner_dimensions.reverse
+      @inner_length, @inner_width, @inner_height = *@inner_dimensions
     end
-
-    alias :inner_x :inner_length
-    alias :inner_y :inner_width
-    alias :inner_z :inner_height
-    alias :inner_depth :inner_height
 
     def inner_volume
       Measured::Volume(

--- a/lib/physical/cuboid.rb
+++ b/lib/physical/cuboid.rb
@@ -11,14 +11,9 @@ module Physical
       @weight = Types::Weight[weight]
       @dimensions = []
       @dimensions = fill_dimensions(Types::Dimensions[dimensions])
-      @length, @width, @height = *@dimensions.reverse
+      @length, @width, @height = *@dimensions
       @properties = properties
     end
-
-    alias :x :length
-    alias :y :width
-    alias :z :height
-    alias :depth :height
 
     def volume
       Measured::Volume(dimensions.map { |d| d.convert_to(:cm).value }.reduce(1, &:*), :ml)
@@ -33,7 +28,7 @@ module Physical
     def fill_dimensions(dimensions)
       dimensions.fill(dimensions.length..2) do |index|
         @dimensions[index] || Measured::Length(self.class::DEFAULT_LENGTH, :cm)
-      end.sort
+      end
     end
   end
 end

--- a/lib/physical/package.rb
+++ b/lib/physical/package.rb
@@ -12,7 +12,7 @@ module Physical
       @items = Set[*items]
     end
 
-    delegate [:dimensions, :width, :length, :height, :depth, :x, :y, :z, :properties] => :container
+    delegate [:dimensions, :width, :length, :height, :properties] => :container
 
     def <<(item)
       @items.add(item)

--- a/lib/physical/spec_support/shared_examples.rb
+++ b/lib/physical/spec_support/shared_examples.rb
@@ -5,9 +5,9 @@ RSpec.shared_examples 'a cuboid' do
     {
       dimensions: [
         Measured::Length.new(1.1, :cm),
-        Measured::Length.new(2.2, :cm),
-        Measured::Length.new(3.3, :cm)
-      ].shuffle
+        Measured::Length.new(3.3, :cm),
+        Measured::Length.new(2.2, :cm)
+      ]
     }
   end
 
@@ -17,19 +17,15 @@ RSpec.shared_examples 'a cuboid' do
     expect(subject.dimensions).to eq(
       [
         Measured::Length.new(1.1, :cm),
-        Measured::Length.new(2.2, :cm),
-        Measured::Length.new(3.3, :cm)
+        Measured::Length.new(3.3, :cm),
+        Measured::Length.new(2.2, :cm)
       ]
     )
   end
 
   it "has getter methods for each dimension as Measured::Length object" do
-    expect(subject.length).to eq(Measured::Length.new(3.3, :cm))
-    expect(subject.x).to eq(Measured::Length.new(3.3, :cm))
-    expect(subject.width).to eq(Measured::Length.new(2.2, :cm))
-    expect(subject.y).to eq(Measured::Length.new(2.2, :cm))
-    expect(subject.height).to eq(Measured::Length.new(1.1, :cm))
-    expect(subject.z).to eq(Measured::Length.new(1.1, :cm))
-    expect(subject.depth).to eq(Measured::Length.new(1.1, :cm))
+    expect(subject.length).to eq(Measured::Length.new(1.1, :cm))
+    expect(subject.width).to eq(Measured::Length.new(3.3, :cm))
+    expect(subject.height).to eq(Measured::Length.new(2.2, :cm))
   end
 end

--- a/lib/physical/version.rb
+++ b/lib/physical/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Physical
-  VERSION = "0.2.0"
+  VERSION = "0.3"
 end

--- a/spec/physical/box_spec.rb
+++ b/spec/physical/box_spec.rb
@@ -103,9 +103,9 @@ RSpec.describe Physical::Box do
 
       it do
         is_expected.to eq([
+          Measured::Length.new(3, :cm),
           Measured::Length.new(1, :cm),
-          Measured::Length.new(2, :cm),
-          Measured::Length.new(3, :cm)
+          Measured::Length.new(2, :cm)
         ])
       end
     end
@@ -120,8 +120,8 @@ RSpec.describe Physical::Box do
 
       it 'fills up with the outer dimensions' do
         is_expected.to eq([
-          Measured::Length.new(1, :cm),
           Measured::Length.new(2, :cm),
+          Measured::Length.new(1, :cm),
           Measured::Length.new(3.2, :cm)
         ])
       end
@@ -140,13 +140,9 @@ RSpec.describe Physical::Box do
 
     it 'does the correct calculations' do
       aggregate_failures do
-        expect(subject.inner_length).to eq(Measured::Length(3, :cm))
-        expect(subject.inner_width).to eq(Measured::Length(2, :cm))
-        expect(subject.inner_height).to eq(Measured::Length(1, :cm))
-        expect(subject.inner_x).to eq(Measured::Length(3, :cm))
-        expect(subject.inner_y).to eq(Measured::Length(2, :cm))
-        expect(subject.inner_z).to eq(Measured::Length(1, :cm))
-        expect(subject.inner_depth).to eq(Measured::Length(1, :cm))
+        expect(subject.inner_length).to eq(Measured::Length(2, :cm))
+        expect(subject.inner_width).to eq(Measured::Length(1, :cm))
+        expect(subject.inner_height).to eq(Measured::Length(3, :cm))
         expect(subject.inner_volume).to eq(Measured::Volume(6, :ml))
       end
     end

--- a/spec/physical/item_spec.rb
+++ b/spec/physical/item_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe Physical::Item do
     specify "the other dimensions are filled up with 0" do
       expect(subject.dimensions).to eq(
         [
+          Measured::Length.new(2, :cm),
           Measured::Length.new(0, :cm),
-          Measured::Length.new(0, :cm),
-          Measured::Length.new(2, :cm)
+          Measured::Length.new(0, :cm)
         ]
       )
     end
@@ -25,9 +25,9 @@ RSpec.describe Physical::Item do
     it "the last dimension is filled up with 0" do
       expect(subject.dimensions).to eq(
         [
-          Measured::Length.new(0, :cm),
           Measured::Length.new(1, :cm),
-          Measured::Length.new(2, :cm)
+          Measured::Length.new(2, :cm),
+          Measured::Length.new(0, :cm)
         ]
       )
     end

--- a/spec/physical/package_spec.rb
+++ b/spec/physical/package_spec.rb
@@ -115,10 +115,10 @@ RSpec.describe Physical::Package do
       end
 
       it 'keeps that weight and has infinite dimensions' do
-        expect(package.weight).to eq(Measured::Weight(0, :lb))
-        expect(package.length).to eq(Measured::Length(3, :cm))
+        expect(package.length).to eq(Measured::Length(1, :cm))
         expect(package.width).to eq(Measured::Length(2, :cm))
-        expect(package.height).to eq(Measured::Length(1, :cm))
+        expect(package.height).to eq(Measured::Length(3, :cm))
+        expect(package.weight).to eq(Measured::Weight(0, :lb))
       end
     end
 
@@ -132,9 +132,9 @@ RSpec.describe Physical::Package do
 
       it 'keeps that weight and has infinite dimensions' do
         expect(package.weight).to eq(Measured::Weight(0.8, :lb))
-        expect(package.length).to eq(Measured::Length(3, :cm))
+        expect(package.length).to eq(Measured::Length(1, :cm))
         expect(package.width).to eq(Measured::Length(2, :cm))
-        expect(package.height).to eq(Measured::Length(1, :cm))
+        expect(package.height).to eq(Measured::Length(3, :cm))
       end
     end
 
@@ -158,9 +158,9 @@ RSpec.describe Physical::Package do
     let(:args) { { container: Physical::Box.new(dimensions: [1,2,3].map { |d| Measured::Length(d, :cm)}) } }
 
     it 'forwards them to the container' do
-      expect(package.length).to eq(Measured::Length(3, :cm))
+      expect(package.length).to eq(Measured::Length(1, :cm))
       expect(package.width).to eq(Measured::Length(2, :cm))
-      expect(package.depth).to eq(Measured::Length(1, :cm))
+      expect(package.height).to eq(Measured::Length(3, :cm))
     end
   end
 


### PR DESCRIPTION
When a user sends the dimensions, we take the first dimension as length,
the second as width, and the third as height. We document this, and thus
now have support for packages that are taller than wide, for example,
but cannot be turned around.

This commit also removes all 'convenience' methods that further increase
the confusion about what exactly constitutes the 'lenght', 'width' or
'height' of a package. We especially eschew the notion of 'depth',
because that word can either mean 'how deep' (how high from the ground)
or 'how far away from the front side'.