### PR TITLE
Remove deprecation warning from `Dry::Types`

### DIFF
--- a/lib/physical/types.rb
+++ b/lib/physical/types.rb
@@ -3,7 +3,7 @@ require 'dry-types'
 
 module Physical
   module Types
-    include Dry::Types.module
+    include Dry.Types
 
     Weight = Types.Instance(::Measured::Weight)
     Length = Types.Instance(::Measured::Length)

--- a/lib/physical/version.rb
+++ b/lib/physical/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Physical
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end


### PR DESCRIPTION
Rather than calling `.module`, we should now be using `Dry.Types`. No functionality changes, and one less deprecation warning.