### PR TITLE
Add properties methods to item

### DIFF
--- a/lib/physical/cuboid.rb
+++ b/lib/physical/cuboid.rb
@@ -25,6 +25,19 @@ module Physical
 
     private
 
+    def method_missing(method)
+      symbolized_properties = properties.symbolize_keys
+      if symbolized_properties.key?(method)
+        symbolized_properties[method]
+      else
+        super
+      end
+    end
+
+    def respond_to_missing?(method, *args)
+      properties.symbolize_keys.key?(method) || super
+    end
+
     def fill_dimensions(dimensions)
       dimensions.fill(dimensions.length..2) do |index|
         @dimensions[index] || Measured::Length(self.class::DEFAULT_LENGTH, :cm)

--- a/lib/physical/cuboid.rb
+++ b/lib/physical/cuboid.rb
@@ -25,17 +25,25 @@ module Physical
 
     private
 
+    NORMALIZED_METHOD_REGEX = /(\w+)\??$/
+
     def method_missing(method)
       symbolized_properties = properties.symbolize_keys
-      if symbolized_properties.key?(method)
-        symbolized_properties[method]
+      method_name = normalize_method_name(method)
+      if symbolized_properties.key?(method_name)
+        symbolized_properties[method_name]
       else
         super
       end
     end
 
     def respond_to_missing?(method, *args)
-      properties.symbolize_keys.key?(method) || super
+      method_name = normalize_method_name(method)
+      properties.symbolize_keys.key?(method_name) || super
+    end
+
+    def normalize_method_name(method)
+      method.to_s.sub(NORMALIZED_METHOD_REGEX, '\1').to_sym
     end
 
     def fill_dimensions(dimensions)

--- a/spec/physical/item_spec.rb
+++ b/spec/physical/item_spec.rb
@@ -118,13 +118,27 @@ RSpec.describe Physical::Item do
       end
     end
 
-    context 'if method is a boolean property with a falsey value' do
+    context 'if method is a boolean property' do
       let(:item) do
-        FactoryBot.build(:physical_item, properties: { already_packaged: false })
+        FactoryBot.build(:physical_item, properties: { already_packaged: true })
       end
 
-      it 'returns its value' do
-        expect(item.already_packaged).to be(false)
+      it 'it is also accessible by its predicate method' do
+        expect(item.already_packaged?).to be(true)
+      end
+
+      it 'it also responds to its predicate method' do
+        expect(item.respond_to?(:already_packaged?)).to be(true)
+      end
+
+      context 'with a falsey value' do
+        let(:item) do
+          FactoryBot.build(:physical_item, properties: { already_packaged: false })
+        end
+
+        it 'returns its value' do
+          expect(item.already_packaged).to be(false)
+        end
       end
     end
 

--- a/spec/physical/item_spec.rb
+++ b/spec/physical/item_spec.rb
@@ -89,6 +89,60 @@ RSpec.describe Physical::Item do
     it { is_expected.to eq(flammable: true) }
   end
 
+  describe 'properties methods' do
+    context 'if method is a property' do
+      let(:item) do
+        FactoryBot.build(:physical_item, properties: { already_packaged: true })
+      end
+
+      it 'returns its value' do
+        expect(item.already_packaged).to be(true)
+      end
+
+      it 'responds to method' do
+        expect(item.respond_to?(:already_packaged)).to be(true)
+      end
+    end
+
+    context 'if method is a string property' do
+      let(:item) do
+        FactoryBot.build(:physical_item, properties: { 'already_packaged' => true })
+      end
+
+      it 'returns its value' do
+        expect(item.already_packaged).to be(true)
+      end
+
+      it 'responds to method' do
+        expect(item.respond_to?(:already_packaged)).to be(true)
+      end
+    end
+
+    context 'if method is a boolean property with a falsey value' do
+      let(:item) do
+        FactoryBot.build(:physical_item, properties: { already_packaged: false })
+      end
+
+      it 'returns its value' do
+        expect(item.already_packaged).to be(false)
+      end
+    end
+
+    context 'if method is not a property' do
+      let(:item) do
+        FactoryBot.build(:physical_item, properties: {})
+      end
+
+      it 'raises method missing' do
+        expect { item.already_packaged? }.to raise_error(NoMethodError)
+      end
+
+      it 'does not respond to method' do
+        expect(item.respond_to?(:already_packaged?)).to be(false)
+      end
+    end
+  end
+
   describe 'factory' do
     subject { FactoryBot.build(:physical_item) }
 


### PR DESCRIPTION
## Add properties method shortcuts to cuboid

A cuboid with properties `{ flammable: true }` can now also be used like

```rb
item.flammable
# => true
```

Raises `NoMethodError` and `respond_to?` returns `false` if the property is not existing.

### Treats String properties as well

A cuboid with `{ 'flammable' => true }` is working as well.

```rb
item.flammable
# => true
```

### Has support for predicate methods

A cuboid with a `{ flammable: true }` property works with

```rb
item.flammable?
# => true
```

as well.