### PR TITLE
Add traits to package factory

### DIFF
--- a/lib/physical/spec_support/factories/package_factory.rb
+++ b/lib/physical/spec_support/factories/package_factory.rb
@@ -6,9 +6,15 @@ require_relative 'item_factory'
 
 FactoryBot.define do
   factory :physical_package, class: "Physical::Package" do
-    container { FactoryBot.build(:physical_box) }
-    items { build_list(:physical_item, 2) }
     void_fill_density { Measured::Weight(0.01, :g) }
     initialize_with { new(attributes) }
+
+    trait :with_container do
+      container { FactoryBot.build(:physical_box) }
+    end
+
+    trait :with_items do
+      items { build_list(:physical_item, 2) }
+    end
   end
 end

--- a/spec/physical/package_spec.rb
+++ b/spec/physical/package_spec.rb
@@ -233,7 +233,31 @@ RSpec.describe Physical::Package do
     subject { FactoryBot.build(:physical_package) }
 
     it 'has plausible attributes' do
-      expect(subject.weight).to eq(Measured::Weight(1327.37, :g))
+      expect(subject.weight).to eq(Measured::Weight(0, :g))
+    end
+
+    context 'with items' do
+      subject { FactoryBot.build(:physical_package, :with_items) }
+
+      it 'has plausible attributes' do
+        expect(subject.weight).to eq(Measured::Weight(100, :g))
+      end
+    end
+
+    context 'with container' do
+      subject { FactoryBot.build(:physical_package, :with_container) }
+
+      it 'has plausible attributes' do
+        expect(subject.weight).to eq(Measured::Weight(1227.49, :g))
+      end
+    end
+
+    context 'with items and container' do
+      subject { FactoryBot.build(:physical_package, :with_container, :with_items) }
+
+      it 'has plausible attributes' do
+        expect(subject.weight).to eq(Measured::Weight(1327.37, :g))
+      end
     end
   end
 


### PR DESCRIPTION
In specs you sometimes want to build a package that does not have items or a container yet.