### PR TITLE
Fix Physical::Location#to_hash to use "region"

### DIFF
--- a/lib/physical/location.rb
+++ b/lib/physical/location.rb
@@ -77,7 +77,7 @@ module Physical
       {
         country: country.code,
         postal_code: zip,
-        province: province.code,
+        region: region.code,
         city: city,
         name: name,
         address1: address1,

--- a/spec/physical/location_spec.rb
+++ b/spec/physical/location_spec.rb
@@ -99,4 +99,17 @@ RSpec.describe Physical::Location do
       expect(subject.company_name).to eq("Company")
     end
   end
+
+  describe 'to_hash' do
+    subject { location.to_hash }
+    let(:location) { FactoryBot.build(:physical_location) }
+
+    it do
+      is_expected.to match(
+        hash_including(
+          region: 'IL'
+        )
+      )
+    end
+  end
 end


### PR DESCRIPTION
Prior to this commit, this used the `province` instead, which we don't
actually support.