### PR TITLE
Update default package dimensions to be a plausible box

### DIFF
--- a/lib/physical/spec_support/factories/box_factory.rb
+++ b/lib/physical/spec_support/factories/box_factory.rb
@@ -4,7 +4,7 @@ require 'factory_bot'
 
 FactoryBot.define do
   factory :physical_box, class: "Physical::Box" do
-    dimensions { [4, 5, 6].map { |d| Measured::Length(d, :dm) } }
+    dimensions { [20, 15, 30].map { |d| Measured::Length(d, :cm) } }
     inner_dimensions { dimensions.map { |d| d - Measured::Length(1, :cm) } }
     weight { Measured::Weight(0.1, :kg) }
     initialize_with { new(attributes) }

--- a/spec/physical/box_spec.rb
+++ b/spec/physical/box_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Physical::Box do
     subject { FactoryBot.build(:physical_box) }
 
     it 'has coherent attributes' do
-      expect(subject.dimensions.map { |d| d.convert_to(:cm).value }).to eq([40, 50, 60])
+      expect(subject.dimensions.map { |d| d.convert_to(:cm).value }).to eq([20, 15, 30])
       expect(subject.weight.convert_to(:g).value).to eq(100)
     end
   end

--- a/spec/physical/package_spec.rb
+++ b/spec/physical/package_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe Physical::Package do
     subject { FactoryBot.build(:physical_package) }
 
     it 'has plausible attributes' do
-      expect(subject.weight).to eq(Measured::Weight(1327.37, :g))
+      expect(subject.weight).to eq(Measured::Weight(277.02, :g))
     end
   end
 


### PR DESCRIPTION
The previous box was very large at 40x50x60 cm. This commit changes the
factory to be a more realistic postal package.