### PR TITLE
Add volume to package

### DIFF
--- a/lib/physical/package.rb
+++ b/lib/physical/package.rb
@@ -12,7 +12,7 @@ module Physical
       @items = Set[*items]
     end
 
-    delegate [:dimensions, :width, :length, :height, :properties] => :container
+    delegate [:dimensions, :width, :length, :height, :properties, :volume] => :container
 
     def <<(item)
       @items.add(item)

--- a/spec/physical/package_spec.rb
+++ b/spec/physical/package_spec.rb
@@ -200,6 +200,14 @@ RSpec.describe Physical::Package do
     end
   end
 
+  describe '#volume' do
+    let(:args) { { container: Physical::Box.new(dimensions: [1,2,3].map { |d| Measured::Length(d, :cm)}) } }
+
+    it 'is the container volume' do
+      expect(package.volume).to eq(Measured::Volume(6, :ml))
+    end
+  end
+
   describe "#remaining_volume" do
     let(:args) do
       {


### PR DESCRIPTION
Builds on top of #19 because I need both additions in my code that is consuming physical.

In the scenario were a package contains other packages the `remaining_volume` calculation breaks, because it depends on the items (in this case another `Physical::Package`) `volume`.

Delegating the package volume to its container volume to fix this.

Also it is convinient to have the packages (outer-)volume as well.