### PR TITLE
Use density type for density

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.4.0] - 2019-07-10
+### Added
+- `Measured::Density` Type and density calculations [@tvdeyen](https://github.com/mamhoff/physical/pull/19)
+- Use `Measured::Density` Type when initializing `Physical::Package#void_fill_density` [@mamhoff](https://github.com/mamhoff/physical/pull/22)

--- a/lib/physical/package.rb
+++ b/lib/physical/package.rb
@@ -5,9 +5,9 @@ module Physical
     extend Forwardable
     attr_reader :container, :items, :void_fill_density, :id
 
-    def initialize(id: nil, container: nil, items: [], void_fill_density: Measured::Weight(0, :g), dimensions: nil, weight: nil, properties: {})
+    def initialize(id: nil, container: nil, items: [], void_fill_density: Measured::Density(0, :g_ml), dimensions: nil, weight: nil, properties: {})
       @id = id || SecureRandom.uuid
-      @void_fill_density = Types::Weight[void_fill_density]
+      @void_fill_density = Types::Density[void_fill_density]
       @container = container || Physical::Box.new(dimensions: dimensions || [], weight: weight || Measured::Weight(0, :g), properties: properties)
       @items = Set[*items]
     end
@@ -35,7 +35,7 @@ module Physical
     def void_fill_weight
       return Measured::Weight(0, :g) if container.volume.value.infinite?
 
-      Measured::Weight(void_fill_density.value * remaining_volume.value, void_fill_density.unit)
+      Measured::Weight(void_fill_density.convert_to(:g_ml).value * remaining_volume.convert_to(:ml).value, :g)
     end
 
     def density

--- a/lib/physical/spec_support/factories/package_factory.rb
+++ b/lib/physical/spec_support/factories/package_factory.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
   factory :physical_package, class: "Physical::Package" do
     container { FactoryBot.build(:physical_box) }
     items { build_list(:physical_item, 2) }
-    void_fill_density { Measured::Weight(0.01, :g) }
+    void_fill_density { Measured::Density(0.01, :g_ml) }
     initialize_with { new(attributes) }
   end
 end

--- a/lib/physical/types.rb
+++ b/lib/physical/types.rb
@@ -8,6 +8,7 @@ module Physical
     Weight = Types.Instance(::Measured::Weight)
     Length = Types.Instance(::Measured::Length)
     Volume = Types.Instance(::Measured::Volume)
+    Density = Types.Instance(::Measured::Density)
 
     Dimensions = Types::Strict::Array.of(Length)
   end

--- a/lib/physical/version.rb
+++ b/lib/physical/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Physical
-  VERSION = "0.3.3"
+  VERSION = "0.4.0"
 end

--- a/spec/physical/package_spec.rb
+++ b/spec/physical/package_spec.rb
@@ -256,7 +256,7 @@ RSpec.describe Physical::Package do
         )
       end
 
-      let(:args) { {container: container, void_fill_density: Measured::Weight.new(7, :mg)} }
+      let(:args) { {container: container, void_fill_density: Measured::Density.new(0.007, :g_ml)} }
 
       it 'calculates the void fill weight from inner dimensions' do
         is_expected.to be_a(Measured::Weight)


### PR DESCRIPTION
This enforces using the Measured::Density type for the package's `void_fill_density`. It also adds a changelog and prepares version 0.4.0 :package: .