### PR TITLE
Add max_weight to Physical::Box

### DIFF
--- a/lib/physical/box.rb
+++ b/lib/physical/box.rb
@@ -5,15 +5,19 @@ require 'measured'
 module Physical
   class Box < Cuboid
     DEFAULT_LENGTH = BigDecimal::INFINITY
+    DEFAULT_MAX_WEIGHT = BigDecimal::INFINITY
+
     attr_reader :inner_dimensions,
                 :inner_length,
                 :inner_width,
-                :inner_height
+                :inner_height,
+                :max_weight
 
-    def initialize(inner_dimensions: [], **args)
+    def initialize(inner_dimensions: [], max_weight: Measured::Weight(DEFAULT_MAX_WEIGHT, :g), **args)
       super args
       @inner_dimensions = fill_dimensions(Types::Dimensions[inner_dimensions])
       @inner_length, @inner_width, @inner_height = *@inner_dimensions
+      @max_weight = Types::Weight[max_weight]
     end
 
     def inner_volume

--- a/spec/physical/box_spec.rb
+++ b/spec/physical/box_spec.rb
@@ -102,6 +102,20 @@ RSpec.describe Physical::Box do
     end
   end
 
+  describe "#max_weight" do
+    subject { described_class.new(args).max_weight }
+
+    context "with no max_weight given" do
+      let(:args) { {} }
+      it { is_expected.to eq(Measured::Weight(BigDecimal::INFINITY, :g)) }
+    end
+
+    context "with a max_weight unit given" do
+      let(:args) { {max_weight: Measured::Weight(1, :lbs)} }
+      it { is_expected.to eq(Measured::Weight(453.59237, :g)) }
+    end
+  end
+
   describe 'factory' do
     subject { FactoryBot.build(:physical_box) }
 


### PR DESCRIPTION
If you want to do weight based item distribution with
`Physical::Package`s we need to have the ability to set
a `max_weight` on containers.