### PR TITLE
Relax Measured gem dependency

### DIFF
--- a/lib/physical/version.rb
+++ b/lib/physical/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Physical
-  VERSION = "0.4.1"
+  VERSION = "0.4.2"
 end

--- a/physical.gemspec
+++ b/physical.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = '>= 2.4'
   spec.add_runtime_dependency "carmen", "~> 1.0"
-  spec.add_runtime_dependency "measured", "~> 2.4.0"
+  spec.add_runtime_dependency "measured", "~> 2.4"
   spec.add_runtime_dependency "dry-types", "~> 1.0.0"
 
   spec.add_development_dependency "bundler", [">= 1.16", "< 3"]


### PR DESCRIPTION
The measured gem which we use for units has recent versions with nice
optimizations, especially regarding memoization. Those versions work
with Physical, so we should allow them.

Especially this PR, the only change from 2.5.0 to 2.5.1 solves an issue where running `Measured::Weight(1, :pounds).freeze.inspect` would blow up: https://github.com/Shopify/measured/pull/126/files